### PR TITLE
feat: Make search exclusions configurable via CodebaseContext

### DIFF
--- a/gemini_stacktrace/models/config.py
+++ b/gemini_stacktrace/models/config.py
@@ -3,7 +3,7 @@ Configuration models for the gemini-stacktrace application.
 """
 
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Optional, List # Make sure List is imported
 import os
 
 from pydantic import (
@@ -105,6 +105,20 @@ class CodebaseContext(BaseModel):
     
     project_dir: AbsolutePath = Field(
         description="Absolute path to the project directory"
+    )
+    
+    excluded_dirs: List[str] = Field(
+        default_factory=lambda: [
+            "__pycache__", "venv", ".venv", "node_modules", 
+            "dist", "build", ".git", ".hg", ".svn",
+            ".vscode", ".idea", "docs",
+        ],
+        description="List of directory names to exclude from searches. Default includes common virtual env, SCM, build, and IDE folders."
+    )
+    
+    excluded_file_patterns: List[str] = Field(
+        default_factory=lambda: ["*.pyc", "*.pyo", "*.log"],
+        description="List of glob file patterns to exclude from searches (e.g., '*.log', '*.tmp'). Default includes Python bytecode files and logs."
     )
     
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/gemini_stacktrace/tools/codebase_tools.py
+++ b/gemini_stacktrace/tools/codebase_tools.py
@@ -153,14 +153,7 @@ def register_tools(agent: Agent[CodebaseContext, str], max_retries: int = 1) -> 
                         continue
 
                     # Skip common directories that shouldn't contain Python code
-                    if os.path.isdir(item_path) and item in {
-                        "__pycache__",
-                        "venv",
-                        ".venv",
-                        "node_modules",
-                        "dist",
-                        "build",
-                    }:
+                    if os.path.isdir(item_path) and item in ctx.deps.excluded_dirs:
                         continue
 
                     if os.path.isdir(item_path):
@@ -169,6 +162,11 @@ def register_tools(agent: Agent[CodebaseContext, str], max_retries: int = 1) -> 
                     elif os.path.isfile(item_path):
                         # If file pattern is specified, filter files
                         if file_pattern and not fnmatch.fnmatch(item, file_pattern):
+                            continue
+
+                        # Skip if file matches any excluded patterns
+                        if ctx.deps.excluded_file_patterns and \
+                           any(fnmatch.fnmatch(item, pattern) for pattern in ctx.deps.excluded_file_patterns):
                             continue
 
                         # Skip if file has been visited
@@ -232,14 +230,7 @@ def register_tools(agent: Agent[CodebaseContext, str], max_retries: int = 1) -> 
                         continue
 
                     # Skip common directories that shouldn't contain Python code
-                    if os.path.isdir(item_path) and item in {
-                        "__pycache__",
-                        "venv",
-                        ".venv",
-                        "node_modules",
-                        "dist",
-                        "build",
-                    }:
+                    if os.path.isdir(item_path) and item in ctx.deps.excluded_dirs:
                         continue
 
                     if os.path.isdir(item_path):
@@ -248,6 +239,11 @@ def register_tools(agent: Agent[CodebaseContext, str], max_retries: int = 1) -> 
                     elif os.path.isfile(item_path):
                         # If file pattern is specified, filter files
                         if file_pattern and not fnmatch.fnmatch(item, file_pattern):
+                            continue
+
+                        # Skip if file matches any excluded patterns
+                        if ctx.deps.excluded_file_patterns and \
+                           any(fnmatch.fnmatch(item, pattern) for pattern in ctx.deps.excluded_file_patterns):
                             continue
 
                         # Skip if file has been visited


### PR DESCRIPTION
This commit introduces configurable search exclusions.

Key changes:
- Added `excluded_dirs` and `excluded_file_patterns` fields to the `CodebaseContext` model in `gemini_stacktrace/models/config.py`. These fields have sensible defaults for common project structures.
- Modified the `find_in_files` and `_search_files` functions in `gemini_stacktrace/tools/codebase_tools.py` to respect these new configuration options, allowing you to customize which directories and file patterns are ignored during searches.
- Updated unit tests in `tests/test_codebase_tools.py` to verify the functionality of default and custom exclusions.
- Updated `docs/codebase_search.md` to document the new configuration options and how they can be used.

This change allows for more flexible and precise control over the scope of codebase searches.